### PR TITLE
Remove the uneeded echo that break some password in copy-pw.sh

### DIFF
--- a/scripts/copy-pw.sh
+++ b/scripts/copy-pw.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env zsh
 
-echo -n "$(pass show "$*" | head -n1)"
+pass show "$*" | head -n1


### PR DESCRIPTION
Hello,

First, thank you for your work on this, I really appreciate this plugin.

Here is a small fix for an issue I'm regularly having with a lot of my passwords. They handup being copied wrong, and I figured out why: the `echo` command in the copy-pw.sh is not needed, and actually breaks password that contains characters that are interpreted by zsh (like \x, ``, $ followed by anything, and others.)